### PR TITLE
`DEBIAN_FRONTEND=noninteractive`を設定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE=ubuntu:focal
 FROM $BASE_IMAGE
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # https://www.nasm.us/
 ARG NASM_VERSION=2.14.02
 # https://code.videolan.org/videolan/x264.git


### PR DESCRIPTION
aptパッケージインストール時に入力を要求されてビルドが止まってしまうのを防ぐ