### PR TITLE
ci: update build workflow for latest/edge tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Docker registry
+name: Build
 
 on:
   push:
@@ -8,12 +8,17 @@ on:
     types:
       - created
 
+# Minimal permissions for pushing images to GHCR
+permissions:
+  contents: read
+  packages: write
+
 env:
   IMAGE_NAME: aoirint/ffmpeg
-  IMAGE_TAG: ${{ github.event.release.tag_name != '' && github.event.release.tag_name || 'latest' }}
+  GHCR_IMAGE_NAME: ghcr.io/aoirint/ffmpeg
 
 jobs:
-  push:
+  build-docker:
     strategy:
       fail-fast: false
       matrix:
@@ -47,39 +52,76 @@ jobs:
             ffmpeg_version: '7.0.1-aoirint.1'
             enable_nvcodec: '0'
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
+      # Checkout repository
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
+      # Enable Buildx for cache and multi-platform builds
+      - name: Setup Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - name: Login to docker hub
-        uses: docker/login-action@v3
+      # Authenticate to Docker Hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
-          registry: docker.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        env:
-          IMAGE_NAME_AND_TAG: ${{ format('{0}:{1}{2}{3}', env.IMAGE_NAME, matrix.tag_prefix, env.IMAGE_TAG, matrix.tag_suffix) }}
-          IMAGE_CACHE_FROM: ${{ format('type=registry,ref={0}:{1}latest{2}-buildcache', env.IMAGE_NAME, matrix.tag_prefix, matrix.tag_suffix) }}
-          IMAGE_CACHE_TO: ${{ env.IMAGE_TAG == 'latest' && format('type=registry,ref={0}:{1}latest{2}-buildcache,mode=max', env.IMAGE_NAME, matrix.tag_prefix, matrix.tag_suffix) || '' }}
+      # Authenticate to GHCR
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
-          push: true
-          builder: ${{ steps.buildx.outputs.name }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Generate tags, labels, and annotations
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+            ${{ env.GHCR_IMAGE_NAME }}
+          # Disable auto-latest to control it explicitly
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ format('{0}edge{1}', matrix.tag_prefix, matrix.tag_suffix) }},enable=${{ github.event_name == 'push' }}
+            type=raw,value=${{ format('{0}{1}{2}', matrix.tag_prefix, github.event.release.tag_name, matrix.tag_suffix) }},enable=${{ github.event_name == 'release' }}
+            type=raw,value=${{ format('{0}latest{1}', matrix.tag_prefix, matrix.tag_suffix) }},enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+
+      # Choose cache tags for edge vs latest releases
+      - name: Derive build cache refs
+        id: cache
+        run: |-
+          if [[ "${{ github.event_name }}" == "release" && "${{ github.event.release.prerelease }}" == "false" ]]; then
+            echo "cache_from=type=registry,ref=${{ env.GHCR_IMAGE_NAME }}:${{ matrix.tag_prefix }}edge${{ matrix.tag_suffix }}-buildcache" >> "$GITHUB_OUTPUT"
+            echo "cache_from=type=registry,ref=${{ env.GHCR_IMAGE_NAME }}:${{ matrix.tag_prefix }}latest${{ matrix.tag_suffix }}-buildcache" >> "$GITHUB_OUTPUT"
+            echo "cache_to=type=registry,ref=${{ env.GHCR_IMAGE_NAME }}:${{ matrix.tag_prefix }}latest${{ matrix.tag_suffix }}-buildcache,mode=max" >> "$GITHUB_OUTPUT"
+          else
+            echo "cache_from=type=registry,ref=${{ env.GHCR_IMAGE_NAME }}:${{ matrix.tag_prefix }}edge${{ matrix.tag_suffix }}-buildcache" >> "$GITHUB_OUTPUT"
+            echo "cache_to=type=registry,ref=${{ env.GHCR_IMAGE_NAME }}:${{ matrix.tag_prefix }}edge${{ matrix.tag_suffix }}-buildcache,mode=max" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Build and push images
+      - name: Build and Deploy Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
           context: .
+          builder: ${{ steps.buildx.outputs.name }}
           file: ./Dockerfile
+          push: true
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
             FFMPEG_REPOSITORY_URL=${{ matrix.ffmpeg_repository_url }}
             FFMPEG_VERSION=${{ matrix.ffmpeg_version }}
             ENABLE_NVCODEC=${{ matrix.enable_nvcodec }}
-          tags: ${{ env.IMAGE_NAME_AND_TAG }}
-          cache-from: ${{ env.IMAGE_CACHE_FROM }}
-          cache-to: ${{ env.IMAGE_CACHE_TO }} 
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: ${{ steps.cache.outputs.cache_from }}
+          cache-to: ${{ steps.cache.outputs.cache_to }}


### PR DESCRIPTION
## Summary
- align build workflow with latest/edge tagging scheme
- add GHCR metadata and cache handling for release vs push
- keep matrix build args and multi-tag output

## Testing
- not run (workflow change only)