### PR TITLE
ci: add concurrency groups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
     types:
       - created
 
+concurrency:
+  group: ${{ github.event_name == 'release' && format('release-{0}', github.event.release.tag_name) || format('edge-{0}', github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
 env:
   IMAGE_NAME: aoirint/ffmpeg
   IMAGE_TAG: ${{ github.event.release.tag_name != '' && github.event.release.tag_name || 'latest' }}


### PR DESCRIPTION
## Summary
- add concurrency groups to cancel edge builds while keeping release builds running

## Testing
- not run (workflow change only)